### PR TITLE
Fix usage key example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You will need:
 To start in terminal and run in background (linux and mac):
 
 ```
-$ python3 path/to/steam_population_checker.py 608800 20 [your key kere] &
+$ python3 path/to/steam_population_checker.py 608800 20 [your key here] &
 $ disown
 ```
 


### PR DESCRIPTION
## Summary
- correct typo in README usage example

## Testing
- `python3 -m py_compile steam_population_checker.py`


------
https://chatgpt.com/codex/tasks/task_e_6840846746188331afb657d90fa9d792